### PR TITLE
Fixing a bug in the Jupyter notebooks examples

### DIFF
--- a/cosmopipe/samplers/ensemble/emcee.yaml
+++ b/cosmopipe/samplers/ensemble/emcee.yaml
@@ -10,6 +10,10 @@ requirements: [emcee]
 bibtex: [arXiv:1202.3665]
 
 options:
+  eigen_gr_stop:
+    type: float
+    default: 0.03
+    description: threshold for the maximum eigenvalue (-1) of Gelman-Rubin test
   nwalkers:
     type: int
     default: None

--- a/cosmopipe/samplers/ensemble/zeus.yaml
+++ b/cosmopipe/samplers/ensemble/zeus.yaml
@@ -10,6 +10,10 @@ requirements: [zeus-mcmc]
 bibtex: [arXiv:2002.06212]
 
 options:
+  eigen_gr_stop:
+    type: float
+    default: 0.03
+    description: threshold for the maximum eigenvalue (-1) of Gelman-Rubin test
   nwalkers:
     type: int
     default: None


### PR DESCRIPTION
This fixes the errors `ConfigError: Option "eigen_gr_stop" for module [emcee] is not listed as available options in description file` and `ConfigError: Option "eigen_gr_stop" for module [zeus] is not listed as available options in description file` in the example Jupyter notebooks

I grabbed the default values from the description in the `diagnostics` option within each of the files, should all of the quantities described in that description be declared as options in the .yaml files?